### PR TITLE
feat: Pin agent models + web admin/eval model controls

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - "site/**"
+      - "agents/**"
+      - "scripts/build-site.ts"
       - ".github/workflows/deploy-site.yml"
   workflow_dispatch:
 
@@ -25,6 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Sync agent models into site
+        run: bun scripts/build-site.ts
 
       - name: Inject commit SHA into site
         run: |

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -8,12 +8,6 @@ on:
       - "agents/**"
       - "scripts/build-site.ts"
       - ".github/workflows/deploy-site.yml"
-  # Run on every PR targeting main so the `required_deployments` branch rule
-  # (which requires a successful github-pages deployment before merge) is
-  # satisfied. No paths filter here — every PR needs a deployment, otherwise
-  # the check stays "missing" and blocks merge.
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -8,6 +8,12 @@ on:
       - "agents/**"
       - "scripts/build-site.ts"
       - ".github/workflows/deploy-site.yml"
+  # Run on every PR targeting main so the `required_deployments` branch rule
+  # (which requires a successful github-pages deployment before merge) is
+  # satisfied. No paths filter here — every PR needs a deployment, otherwise
+  # the check stays "missing" and blocks merge.
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Run eval tests
+        run: bun test evals/src/__tests__/
+
+      - name: Run web tests
+        run: bun test web/src/__tests__/
+
+      - name: Check site is in sync with agent specs
+        run: bun scripts/build-site.ts --check

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Source of truth for all Claude Code agents and commands. Install once, use every
 
 | Agent | Command | Persona | Role | Model | Max Turns |
 |-------|---------|---------|------|-------|-----------|
-| **bird** | `/bird` | Larry Bird | Domain Authority & Final Arbiter | **opus** | 50 |
-| **mj** | `/mj` | Michael Jordan | Strategic Systems Architect | **opus** | 50 |
-| **shaq** | `/shaq` | Shaquille O'Neal | Primary Code Executor | **opusplan** | 100 |
-| **kobe** | `/kobe` | Kobe Bryant | Quality & Risk Enforcer | **opus** | 50 |
-| **pippen** | `/pippen` | Scottie Pippen | Stability, Integration & Defense | **opus** | 50 |
-| **magic** | `/magic` | Magic Johnson | Context Synthesizer & Team Glue | sonnet | 50 |
+| **bird** | `/bird` | Larry Bird | Domain Authority & Final Arbiter | `claude-opus-4-6` | 50 |
+| **mj** | `/mj` | Michael Jordan | Strategic Systems Architect | `claude-opus-4-6` | 50 |
+| **shaq** | `/shaq` | Shaquille O'Neal | Primary Code Executor | `claude-opus-4-6` | 100 |
+| **kobe** | `/kobe` | Kobe Bryant | Quality & Risk Enforcer | `claude-opus-4-6` | 50 |
+| **pippen** | `/pippen` | Scottie Pippen | Stability, Integration & Defense | `claude-opus-4-6` | 50 |
+| **magic** | `/magic` | Magic Johnson | Context Synthesizer & Team Glue | `claude-sonnet-4-6` | 50 |
+
+All 7 agents (including Coach K) are pinned to specific Claude 4.6 builds instead of floating aliases: 6 on `claude-opus-4-6`, magic on `claude-sonnet-4-6` (synthesis is structured writing, not deep reasoning). Pinning lets us run eval baselines per model version — see [Running eval across model versions](#running-eval-across-model-versions).
 
 ### Agent capabilities
 
@@ -338,21 +340,35 @@ Quality-first, with each agent on the model matching its reasoning demands.
 
 | Model | Agents | Why |
 |-------|--------|-----|
-| **opus** | bird, mj, kobe, pippen | Domain analysis, architecture, quality review, and stability review all require deep reasoning |
-| **opusplan** | shaq | Opus for planning, sonnet for code generation |
-| **sonnet** | magic | Synthesis is structured and doesn't need opus depth |
+| `claude-opus-4-6` | bird, mj, shaq, kobe, pippen, coachk | Domain, architecture, implementation, quality, stability, and orchestration all need deep reasoning |
+| `claude-sonnet-4-6` | magic | Synthesis is structured writing — sonnet depth is enough |
+
+Historical note: shaq previously ran on `opusplan` (plan-mode alias). We pinned every agent to a specific 4.x build so we can run full evals on 4.6 vs 4.7 against an identical config — the only variable between runs is the model version. Magic stays on sonnet across the sweep (4.6 → 4.7 for magic means `claude-sonnet-4-6` → `claude-sonnet-4-7`).
 
 ### Tuning guide
 
 | If you notice... | Try... |
 |-----------------|--------|
-| Magic's synthesis is fine but slow | Downgrade magic to `haiku` |
-| Hitting rate limits on Full Team | Downgrade bird, mj to `sonnet` |
-| Kobe's findings are obvious/shallow | Keep on `opus` — quality is where depth matters most |
-| Pippen's reviews are excellent | Could downgrade to `sonnet` to save rate limits |
-| Shaq's code quality is great | Could downgrade to `sonnet` (saves opus planning cost) |
+| Magic's synthesis is fine but slow | Try a lighter model (`claude-sonnet-4-6` or `claude-haiku-4-5`) |
+| Hitting rate limits on Full Team | Downgrade bird, mj to a sonnet build |
+| Kobe's findings are obvious/shallow | Keep on opus — quality is where depth matters most |
+| Pippen's reviews are excellent | Could downgrade to a sonnet build to save rate limits |
+| Shaq's code quality is great | Could downgrade to a sonnet build |
 
-To change a model: edit `model:` in `agents/<name>.md`, run `bun scripts/install.ts`.
+To change a model permanently: edit `model:` in `agents/<name>.md`, run `bun scripts/install.ts`. To A/B a single run without touching specs, use `bun evals/src/cli.ts --model <id>` (see [Running eval across model versions](#running-eval-across-model-versions)).
+
+### Running eval across model versions
+
+The `agents/*.md` `model:` field is the source of truth. To compare model versions end-to-end:
+
+1. Set every agent's `model:` to the target ID (e.g. `claude-opus-4-6`) — either by editing `agents/*.md` directly or via the web admin at `http://localhost:3000/admin/models`.
+2. `bun scripts/install.ts` — sync the new frontmatter into `~/.claude/`.
+3. `bun scripts/build-site.ts` — mirror the new models into `site/index.html`. CI runs this automatically on deploy, but run locally if you want the preview in sync.
+4. `bun evals/src/cli.ts --trials 3` — eval invokes `claude -p --agent <name>`, picking up the model from the now-installed frontmatter.
+5. Switch `model:` to the next ID (e.g. `claude-opus-4-7`), re-install, re-run.
+6. Compare results at `http://localhost:3000`.
+
+For a quick one-off without editing frontmatter, `bun evals/src/cli.ts --trials 3 --model claude-opus-4-7` overrides the agent's model for that run only. The `--model` flag only affects phase-1 agent runs — the Coach K scoring judge stays on the default so comparisons share a constant baseline.
 
 ### Turn limits
 
@@ -369,12 +385,13 @@ To change a model: edit `model:` in `agents/<name>.md`, run `bun scripts/install
 
 | Agent | Model | Effort Level | Rationale |
 |-------|-------|--------------|-----------|
-| bird  | opus  | high         | Domain analysis benefits from deep reasoning |
-| mj    | opus  | high         | Architecture trade-offs require extended thinking |
-| kobe  | opus  | high         | Code review requires thorough pattern matching |
-| pippen| opus  | high         | Stability review requires thorough integration and operational analysis |
-| shaq  | opusplan | medium    | Implementation is execution-heavy, not reasoning-heavy |
-| magic | sonnet| low          | Synthesis is structured writing, not complex reasoning |
+| bird  | `claude-opus-4-6` | high | Domain analysis benefits from deep reasoning |
+| mj    | `claude-opus-4-6` | high | Architecture trade-offs require extended thinking |
+| kobe  | `claude-opus-4-6` | high | Code review requires thorough pattern matching |
+| pippen| `claude-opus-4-6` | high | Stability review requires thorough integration and operational analysis |
+| shaq  | `claude-opus-4-6` | high | Pinned to match the eval baseline (previously `opusplan`) |
+| magic | `claude-sonnet-4-6` | low | Synthesis is structured writing, not complex reasoning |
+| coachk| `claude-opus-4-6` | high | Orchestration + context curation needs reasoning depth |
 
 > **Warning:** Do NOT set `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1`. Adaptive thinking is active by default and allows the model to dynamically scale its thinking budget. Disabling it removes a meaningful quality lever with no compensating benefit.
 

--- a/agents/bird.md
+++ b/agents/bird.md
@@ -1,7 +1,7 @@
 ---
 name: bird
 description: '"Is this correct?" — Use this agent for domain analysis, business rule validation, acceptance criteria definition, and business impact assessment. Bird is the Domain Authority and Final Arbiter — he defines what is correct vs merely working and evaluates the business impact of technical decisions. Use via `/team` for orchestrated workflows, or directly for standalone domain analysis.\n\n<example>\nContext: Team needs domain rules defined before implementation.\nuser: "/team Add a discount engine for bulk orders"\nassistant: "Launching the Dream Team. Bird will start by defining the domain rules and acceptance criteria for bulk order discounts."\n</example>\n\n<example>\nContext: User needs to validate business logic correctness.\nuser: "Is our pricing calculation faithful to the actual business process?"\nassistant: "I'll use the bird agent to evaluate whether the pricing logic accurately encodes the business rules."\n</example>\n\n<example>\nContext: User needs business impact analysis of a technical change.\nuser: "What's the business impact of refactoring the payment service?"\nassistant: "I'll use the bird agent to evaluate the business implications, stakeholder impact, and domain risks."\n</example>
-model: opus
+model: claude-opus-4-6
 color: green
 tools: Read, Grep, Glob, Bash
 maxTurns: 50

--- a/agents/coachk.md
+++ b/agents/coachk.md
@@ -1,7 +1,7 @@
 ---
 name: coachk
 description: 'Orchestration decisions, context curation, and checkpoint analysis — Use this agent for pipeline coordination, agent routing, context distillation between phases, and escalation handling. Coach K is the Dream Team orchestrator — he decides which agent to spawn next, curates context to prevent bloat, enforces checkpoints, and validates agent output compliance. Use via `/team` for orchestrated workflows, or directly for standalone orchestration decisions.\n\n<example>\nContext: Team needs orchestration decision after Bird completes domain analysis.\nuser: "Bird finished analysis — what next?"\nassistant: "I\'ll use the coachk agent to evaluate the analysis quality, curate context for the next phase, and determine the correct routing decision."\n</example>\n\n<example>\nContext: Multiple agents produced outputs and a checkpoint decision is needed.\nuser: "Bird, MJ, and Kobe all finished their parallel analysis — present the checkpoint"\nassistant: "I\'ll use the coachk agent to consolidate the parallel outputs into a checkpoint comparison and determine the correct next action."\n</example>\n\n<example>\nContext: Agent output needs validation before proceeding.\nuser: "Shaq finished implementation — is it ready for review?"\nassistant: "I\'ll use the coachk agent to validate Shaq\'s output compliance and determine review routing."\n</example>
-model: opus
+model: claude-opus-4-6
 color: blue
 tools: Read, Grep, Glob, Bash
 maxTurns: 50

--- a/agents/kobe.md
+++ b/agents/kobe.md
@@ -1,7 +1,7 @@
 ---
 name: kobe
 description: '"What could break?" — Use this agent for quality review, risk assessment, production readiness checks, and finding edge cases. Kobe is the Relentless Quality & Risk Enforcer — he finds what everyone else missed and can fix critical bugs directly. Use via `/team` for orchestrated workflows, or directly for standalone quality review.\n\n<example>\nContext: Code has been implemented and needs quality review.\nuser: "/team Review the payment processing implementation"\nassistant: "Launching the Dream Team. After implementation, Kobe will hunt for edge cases, race conditions, and hidden risks."\n</example>\n\n<example>\nContext: User wants a ruthless review of critical code.\nuser: "This handles money — find every way it could break"\nassistant: "I'll use the kobe agent to perform a ruthless quality review — he'll find edge cases, race conditions, and failure modes."\n</example>\n\n<example>\nContext: User wants production readiness assessment.\nuser: "Is this ready to deploy? Check everything."\nassistant: "I'll use the kobe agent to perform a full production readiness review — code quality, deployment risks, and operational concerns."\n</example>
-model: opus
+model: claude-opus-4-6
 color: purple
 tools: Read, Grep, Glob, Bash, Edit
 maxTurns: 50

--- a/agents/magic.md
+++ b/agents/magic.md
@@ -1,7 +1,7 @@
 ---
 name: magic
 description: '"Summarize everything." — Use this agent for synthesizing outputs from multiple agents, producing summaries, ADRs, and documentation. Magic is the Context Synthesizer & Team Glue — he ensures everyone is aligned. Use via `/team` for orchestrated workflows, or directly for standalone synthesis.\n\n<example>\nContext: Multiple agents have produced outputs that need synthesis.\nuser: "/team Summarize all the analysis and implementation work"\nassistant: "Launching Magic to synthesize all agent outputs into a coherent summary with decisions, next steps, and documentation."\n</example>\n\n<example>\nContext: User needs a decision documented.\nuser: "We decided to use event sourcing — can you document why?"\nassistant: "I'll use the magic agent to produce an ADR documenting the decision, rationale, and trade-offs."\n</example>
-model: opus
+model: claude-sonnet-4-6
 color: yellow
 tools: Read, Grep, Glob, Write, Edit
 memory: user

--- a/agents/mj.md
+++ b/agents/mj.md
@@ -1,7 +1,7 @@
 ---
 name: mj
 description: '"How should we build this?" — Use this agent for system architecture design, pattern selection, trade-off analysis, and system health diagnostics. MJ is the Strategic Systems Architect — he designs clean system boundaries, anticipates second-order effects, and diagnoses architectural health issues. Use via `/team` for orchestrated workflows, or directly for standalone architecture review.\n\n<example>\nContext: Team needs architecture designed for a new feature.\nuser: "/team Build a real-time notification system"\nassistant: "Launching the Dream Team. After Bird defines domain rules, MJ will design the system architecture."\n</example>\n\n<example>\nContext: User needs architectural guidance on a design decision.\nuser: "Should we use event sourcing or traditional CRUD for the order system?"\nassistant: "I'll use the mj agent to analyze the architectural trade-offs between event sourcing and CRUD."\n</example>\n\n<example>\nContext: User wants a system health check.\nuser: "Our API response times are degrading. What should we investigate?"\nassistant: "I'll use the mj agent to diagnose the architectural bottlenecks and provide strategic recommendations."\n</example>
-model: opus
+model: claude-opus-4-6
 color: red
 tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
 maxTurns: 50

--- a/agents/pippen.md
+++ b/agents/pippen.md
@@ -1,7 +1,7 @@
 ---
 name: pippen
 description: '"Will it stay working?" — Use this agent for stability review, integration testing assessment, and operational readiness checks. Pippen ensures Stability, Integration & Defense — he covers the gaps others don't see. Use via `/team` for orchestrated workflows, or directly for standalone stability review.\n\n<example>\nContext: Implementation needs operational readiness review.\nuser: "/team Check if the new microservice is production-ready"\nassistant: "Launching the Dream Team. Pippen will review integration, observability, and operational readiness."\n</example>\n\n<example>\nContext: User wants to verify cross-cutting concerns.\nuser: "Can we debug this service live? Do we have enough observability?"\nassistant: "I'll use the pippen agent to assess observability, monitoring, and operational readiness."\n</example>
-model: opus
+model: claude-opus-4-6
 color: magenta
 tools: Read, Grep, Glob, Bash
 maxTurns: 50

--- a/agents/shaq.md
+++ b/agents/shaq.md
@@ -1,7 +1,7 @@
 ---
 name: shaq
 description: '"Build it." — Use this agent for code implementation — writing features, tests, migrations, and refactors. Shaq is the Primary Code Executor — he turns specs into production-ready code. Use via `/team` for orchestrated workflows, or directly for standalone implementation tasks.\n\n<example>\nContext: Team has specs ready and needs implementation.\nuser: "/team Implement the user authentication flow"\nassistant: "Launching the Dream Team. After domain analysis and architecture design, Shaq will implement the code."\n</example>\n\n<example>\nContext: User needs a feature implemented from a clear spec.\nuser: "Implement this API endpoint according to the spec in the PR description"\nassistant: "I'll use the shaq agent to implement the endpoint — he'll write production-ready code with tests."\n</example>
-model: opusplan
+model: claude-opus-4-6
 color: purple
 disallowedTools: Task
 maxTurns: 100

--- a/commands/eval.md
+++ b/commands/eval.md
@@ -25,8 +25,12 @@ You (Claude Code) are a **thin wrapper** that:
 |----------------|----------------|
 | `/eval` | `bun evals/src/cli.ts --parallel 10` |
 | `/eval <agent>` | `bun evals/src/cli.ts --agent <agent> --parallel 10` |
+| `/eval --model <id>` | `bun evals/src/cli.ts --parallel 10 --model <id>` (combine with any other flags) |
+| `/eval --trials N` | `bun evals/src/cli.ts --parallel 10 --trials N` (combine with any other flags) |
 | `/eval --report` | Skip CLI: run `bun web/src/migrate.ts`, then open web app (see below) |
 | `/eval --resume` | `bun evals/src/cli.ts --resume evals/results/raw/<latest-dir> --phase score` |
+
+**Model override semantics.** `--model` is passed through to `claude -p --agent <name> --model <id>` for phase-1 agent runs only. The Coach K scoring calls in phase 3 intentionally do NOT receive `--model`, so the judge stays on the user's default model and 4.6 vs 4.7 runs share a constant baseline. Valid IDs include `claude-opus-4-6` and `claude-opus-4-7`; aliases like `opus` or `sonnet` also work (whatever `claude --model` accepts).
 
 ## EXECUTION
 

--- a/commands/team.md
+++ b/commands/team.md
@@ -404,9 +404,9 @@ PR: [number or branch]
 
 | Agent | Model | Role              |
 |-------|-------|-------------------|
-| bird  | opus  | Domain review     |
-| mj    | opus  | Architecture review |
-| kobe  | opus  | Quality/risk review |
+| bird  | claude-opus-4-6 | Domain review |
+| mj    | claude-opus-4-6 | Architecture review |
+| kobe  | claude-opus-4-6 | Quality/risk review |
 
 Output: LOCAL ONLY (docs/PR-<number>-review.md)
 Tip: Run /usage to check rate limit impact.
@@ -957,14 +957,14 @@ Always include this at the end of the final output so the user can see what ran:
 Workflow: [Quick Fix / Full Team]
 Task: [one-line description]
 
-| Agent   | Model     | Role                        |
-|---------|-----------|-----------------------------|
-| bird    | opus      | Domain analysis             |
-| mj      | opus      | Architecture design         |
-| magic   | sonnet    | Context curation + synthesis |
-| shaq    | opusplan  | Implementation              |
-| kobe    | opus      | Quality review              |
-| pippen  | opus      | Stability review            |
+| Agent   | Model             | Role                        |
+|---------|-------------------|-----------------------------|
+| bird    | claude-opus-4-6   | Domain analysis             |
+| mj      | claude-opus-4-6   | Architecture design         |
+| magic   | claude-sonnet-4-6 | Context curation + synthesis |
+| shaq    | claude-opus-4-6   | Implementation              |
+| kobe    | claude-opus-4-6   | Quality review              |
+| pippen  | claude-opus-4-6   | Stability review            |
 
 Tip: Run /usage to check rate limit impact.
 ```

--- a/evals/README.md
+++ b/evals/README.md
@@ -38,6 +38,42 @@ scoring_rubric:    How to grade the output (pass / partial / fail criteria)
 
 Use `bun evals/src/cli.ts` for automated runs (see `--help`), or run manually for human review.
 
+## Running eval across model versions
+
+The `agents/*.md` `model:` field is the source of truth for which model each agent runs on. The eval CLI spawns `claude -p --agent <name>`, so whatever is in the agent's frontmatter is what gets tested.
+
+**Full sweep (source-of-truth workflow):**
+
+```bash
+# 1. Point every agent at the target version
+#    Edit agents/*.md — 6 agents on `claude-opus-4-6`, magic on `claude-sonnet-4-6`
+bun scripts/install.ts
+
+# 2. Run the full eval with 3 trials
+bun evals/src/cli.ts --trials 3
+
+# 3. Switch to the next version
+#    Edit agents/*.md — 6 agents on `claude-opus-4-7`, magic on `claude-sonnet-4-7`
+bun scripts/install.ts
+
+# 4. Re-run
+bun evals/src/cli.ts --trials 3
+
+# 5. Compare runs at http://localhost:3000
+```
+
+Magic stays on sonnet across the sweep — synthesis is structured writing and doesn't need opus depth. The 4.6→4.7 comparison bumps magic from `claude-sonnet-4-6` to `claude-sonnet-4-7`, and the other 6 agents from `claude-opus-4-6` to `claude-opus-4-7`.
+
+**One-off override (no frontmatter churn):**
+
+```bash
+bun evals/src/cli.ts --trials 3 --model claude-opus-4-7
+```
+
+The `--model <id>` flag appends `--model <id>` to the `claude -p --agent <name>` invocation for phase-1 agent runs. The Coach K scoring calls in phase 3 intentionally do NOT receive `--model` — the judge stays on the user's default model so 4.6 and 4.7 runs share a constant baseline. Valid IDs: anything `claude --model` accepts (full IDs like `claude-opus-4-6`, `claude-opus-4-7`, or aliases like `opus`, `sonnet`, `haiku`).
+
+The selected model is recorded in `meta.model` of the final result JSON, so the web app can distinguish runs.
+
 ## Scoring
 
 Each scenario is scored on a three-point scale:

--- a/evals/src/agent-runner.ts
+++ b/evals/src/agent-runner.ts
@@ -82,7 +82,8 @@ export async function runSingleAgentCall(
   scenarioId: string,
   prompt: string,
   adapter: ClaudeAdapter,
-  timeoutMs: number
+  timeoutMs: number,
+  model?: string
 ): Promise<Omit<RawOutput, "phases" | "pipeline_fields">> {
   const timestamp = new Date().toISOString().replace(/\.\d+Z$/, "Z");
   const startMs = Date.now();
@@ -96,20 +97,21 @@ export async function runSingleAgentCall(
   let errorNote = "";
 
   try {
-    const { stdout, exitCode } = await adapter.run(
-      [
-        "-p",
-        "--agent",
-        agent,
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--append-system-prompt",
-        EVAL_MODE_APPEND,
-      ],
-      prompt,
-      timeoutMs
-    );
+    const args = [
+      "-p",
+      "--agent",
+      agent,
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--append-system-prompt",
+      EVAL_MODE_APPEND,
+    ];
+    if (model) {
+      args.push("--model", model);
+    }
+
+    const { stdout, exitCode } = await adapter.run(args, prompt, timeoutMs);
 
     if (exitCode !== 0) {
       errorNote = `claude exited non-zero (exit ${exitCode})`;
@@ -167,7 +169,8 @@ export async function runAgentScenario(
   trial: number,
   adapter: ClaudeAdapter,
   timeoutMs: number,
-  trials: number
+  trials: number,
+  model?: string
 ): Promise<string> {
   const rawOutput =
     trial === 0
@@ -189,7 +192,7 @@ export async function runAgentScenario(
     console.error(`  WARN: empty prompt extracted for ${agent}/${scenarioId}`);
   }
 
-  const record = await runSingleAgentCall(agent, scenarioId, prompt, adapter, timeoutMs);
+  const record = await runSingleAgentCall(agent, scenarioId, prompt, adapter, timeoutMs, model);
 
   fs.writeFileSync(rawOutput, JSON.stringify(record, null, 2), "utf-8");
   console.log(`  Done: ${agent}/${scenarioId}${label} (${record.duration_ms}ms)`);
@@ -224,7 +227,8 @@ export async function runTeamScenario(
   trial: number,
   adapter: ClaudeAdapter,
   timeoutMs: number,
-  trials: number
+  trials: number,
+  model?: string
 ): Promise<string> {
   const rawOutput =
     trial === 0
@@ -280,7 +284,8 @@ export async function runTeamScenario(
         `${scenarioId}/phase-${pn}`,
         phPrompt,
         adapter,
-        timeoutMs
+        timeoutMs,
+        model
       );
       totalInputTokens += record.input_tokens;
       totalOutputTokens += record.output_tokens;

--- a/evals/src/assembler.ts
+++ b/evals/src/assembler.ts
@@ -119,7 +119,8 @@ export function assembleFinalResult(
   scenariosTotal: number,
   allScenariosTotal: number,
   trials: number,
-  repoRoot: string
+  repoRoot: string,
+  model?: string
 ): FinalResult {
   const runId = `eval/run-${runDatetime}`;
   const results = loadScoredResults(scoredDir, runId);
@@ -153,6 +154,7 @@ export function assembleFinalResult(
       trials,
       notes:
         "Preliminary scoring by Coach K. Human review pending via web app at localhost:3000.",
+      ...(model ? { model } : {}),
     },
   };
 }

--- a/evals/src/cli.ts
+++ b/evals/src/cli.ts
@@ -8,6 +8,9 @@
  *   --scenario PAT       Run only scenarios matching glob pattern or comma-separated "agent/id"
  *   --phase PHASE        Phase: agents|graders|score|all (default: all)
  *   --trials N           Run each scenario N times (default: 1)
+ *   --model ID           Override the model for agent runs (e.g. claude-opus-4-6, claude-opus-4-7).
+ *                        Does NOT affect Coach K scoring calls — the judge stays on the default model
+ *                        so 4.6 vs 4.7 runs are compared against a constant baseline.
  *   --dry-run            Show what would run without executing
  *   --timeout-per-phase  Timeout in seconds per phase (default: 300 individual, 600 team)
  */
@@ -28,6 +31,7 @@ function parseArgs(argv: string[]): PipelineOptions & { help: boolean } {
     dryRun: false,
     timeoutPerPhase: 0,
     repoRoot: "",
+    model: "",
     help: false,
   };
 
@@ -50,6 +54,9 @@ function parseArgs(argv: string[]): PipelineOptions & { help: boolean } {
         break;
       case "--trials":
         opts.trials = Math.max(1, parseInt(argv[++i] ?? "1", 10));
+        break;
+      case "--model":
+        opts.model = argv[++i] ?? "";
         break;
       case "--dry-run":
         opts.dryRun = true;
@@ -84,6 +91,7 @@ function printHelp() {
   --scenario PAT        Run only scenarios matching glob pattern or agent/scenario-id
   --phase PHASE         agents|graders|score|all (default: all)
   --trials N            Run each scenario N times (default: 1)
+  --model ID            Override model for agent runs (e.g. claude-opus-4-6). Judge stays on default.
   --dry-run             Show what would run without executing
   --timeout-per-phase N Timeout in seconds per phase (default: 300/600)`);
 }

--- a/evals/src/pipeline.ts
+++ b/evals/src/pipeline.ts
@@ -65,7 +65,8 @@ async function phaseAgents(
         trial,
         adapter,
         teamTimeoutMs,
-        options.trials
+        options.trials,
+        options.model
       );
     } else {
       await runAgentScenario(
@@ -76,7 +77,8 @@ async function phaseAgents(
         trial,
         adapter,
         timeoutMs,
-        options.trials
+        options.trials,
+        options.model
       );
     }
   });
@@ -225,7 +227,8 @@ async function phaseAssemble(
   scenariosTotal: number,
   allScenariosTotal: number,
   trials: number,
-  repoRoot: string
+  repoRoot: string,
+  model?: string
 ): Promise<string> {
   const scoredDir = path.join(rawDir, "scored");
   const finalOutput = path.join(resultsDir, `${runDatetime}.json`);
@@ -243,7 +246,8 @@ async function phaseAssemble(
     scenariosTotal,
     allScenariosTotal,
     trials,
-    repoRoot
+    repoRoot,
+    model
   );
 
   fs.writeFileSync(finalOutput, JSON.stringify(final, null, 2), "utf-8");
@@ -307,6 +311,7 @@ export async function runPipeline(
   console.log(`  Phase        : ${options.phase}`);
   console.log(`  Parallel     : ${options.parallel}`);
   console.log(`  Trials       : ${options.trials}`);
+  console.log(`  Model        : ${options.model || "(agent default)"} ${options.model ? "[judge unchanged]" : ""}`);
   console.log(`  Scenarios    : ${total}`);
   console.log();
 
@@ -389,7 +394,8 @@ export async function runPipeline(
       total,
       allScenariosTotal,
       options.trials,
-      options.repoRoot
+      options.repoRoot,
+      options.model
     );
 
     return {

--- a/evals/src/types.ts
+++ b/evals/src/types.ts
@@ -167,6 +167,7 @@ export interface FinalResult {
     repo_commit: string;
     trials: number;
     notes: string;
+    model?: string;
   };
 }
 
@@ -188,6 +189,7 @@ export interface PipelineOptions {
   dryRun: boolean;
   timeoutPerPhase: number;
   repoRoot: string;
+  model?: string;
 }
 
 export interface DiscoveredScenario {

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * build-site.ts — sync site/index.html model labels with agent frontmatter.
+ *
+ * Reads the `model:` field from each agents/<name>.md and rewrites the
+ * <dt>Model</dt><dd>...</dd> line that follows the matching <h3 class="codename">name</h3>
+ * in site/index.html. Idempotent and safe to run repeatedly.
+ *
+ * Run locally:   bun scripts/build-site.ts
+ * Run in CI:     same — invoked from .github/workflows/deploy-site.yml before deploy
+ *
+ * Flags:
+ *   --check   Exit non-zero if the site is out of sync (CI verification / pre-commit).
+ */
+import path from "path";
+import fs from "fs";
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const AGENTS_DIR = path.join(REPO_ROOT, "agents");
+const SITE_HTML = path.join(REPO_ROOT, "site", "index.html");
+
+/** Agents that appear as cards on site/index.html (coachk has no Model field there). */
+const AGENTS_ON_SITE = ["bird", "mj", "shaq", "kobe", "pippen", "magic"] as const;
+
+const checkOnly = process.argv.includes("--check");
+
+function readAgentModel(agent: string): string {
+  const fp = path.join(AGENTS_DIR, `${agent}.md`);
+  const content = fs.readFileSync(fp, "utf-8");
+  const match = content.match(/^model:\s*(.+)$/m);
+  if (!match) {
+    throw new Error(`No 'model:' field found in ${fp}`);
+  }
+  return match[1].trim();
+}
+
+function rewriteModelForAgent(html: string, agent: string, model: string): { html: string; changed: boolean; current: string } {
+  // Match the agent's <h3 class="codename">agent</h3> then the next <dt>Model</dt><dd>...</dd>.
+  // Lazy match with [\s\S] so we can span multiple lines but stop at the FIRST dd after the h3.
+  const re = new RegExp(
+    `(<h3 class="codename">${agent}</h3>[\\s\\S]*?<dt>Model</dt><dd>)([^<]*)(</dd>)`,
+    "m",
+  );
+  const match = html.match(re);
+  if (!match) {
+    throw new Error(`Could not find <dt>Model</dt><dd>...</dd> block for agent '${agent}' in site/index.html`);
+  }
+  const current = match[2];
+  if (current === model) {
+    return { html, changed: false, current };
+  }
+  return { html: html.replace(re, `$1${model}$3`), changed: true, current };
+}
+
+function main() {
+  let html = fs.readFileSync(SITE_HTML, "utf-8");
+  const results: Array<{ agent: string; model: string; previous: string; changed: boolean }> = [];
+
+  for (const agent of AGENTS_ON_SITE) {
+    const model = readAgentModel(agent);
+    const { html: next, changed, current } = rewriteModelForAgent(html, agent, model);
+    html = next;
+    results.push({ agent, model, previous: current, changed });
+  }
+
+  const changedCount = results.filter((r) => r.changed).length;
+
+  console.log("Site model sync:");
+  for (const r of results) {
+    if (r.changed) {
+      console.log(`  ~ ${r.agent.padEnd(8)} ${r.previous} -> ${r.model}`);
+    } else {
+      console.log(`  = ${r.agent.padEnd(8)} ${r.model}`);
+    }
+  }
+
+  if (checkOnly) {
+    if (changedCount > 0) {
+      console.error(`\nsite/index.html is out of sync with agents/*.md (${changedCount} agent(s) differ).`);
+      console.error("Run: bun scripts/build-site.ts");
+      process.exit(1);
+    }
+    console.log("\nsite/index.html is in sync with agents/*.md.");
+    return;
+  }
+
+  if (changedCount === 0) {
+    console.log("\nsite/index.html already in sync. No changes written.");
+    return;
+  }
+
+  fs.writeFileSync(SITE_HTML, html, "utf-8");
+  console.log(`\nUpdated site/index.html (${changedCount} agent(s)).`);
+}
+
+main();

--- a/site/index.html
+++ b/site/index.html
@@ -115,7 +115,7 @@
           <p class="motto">“Is this correct?”</p>
           <dl class="stats">
             <dt>Cmd</dt><dd class="cmd">/bird</dd>
-            <dt>Model</dt><dd>opus</dd>
+            <dt>Model</dt><dd>claude-opus-4-6</dd>
             <dt>Tools</dt><dd>read-only</dd>
             <dt>Turns</dt><dd>50</dd>
           </dl>
@@ -130,7 +130,7 @@
           <p class="motto">“How should we build this?”</p>
           <dl class="stats">
             <dt>Cmd</dt><dd class="cmd">/mj</dd>
-            <dt>Model</dt><dd>opus</dd>
+            <dt>Model</dt><dd>claude-opus-4-6</dd>
             <dt>Tools</dt><dd>+ web</dd>
             <dt>Turns</dt><dd>50</dd>
           </dl>
@@ -145,7 +145,7 @@
           <p class="motto">“Build it.”</p>
           <dl class="stats">
             <dt>Cmd</dt><dd class="cmd">/shaq</dd>
-            <dt>Model</dt><dd>opusplan</dd>
+            <dt>Model</dt><dd>claude-opus-4-6</dd>
             <dt>Tools</dt><dd>full</dd>
             <dt>Turns</dt><dd>100</dd>
           </dl>
@@ -160,7 +160,7 @@
           <p class="motto">“What could break?”</p>
           <dl class="stats">
             <dt>Cmd</dt><dd class="cmd">/kobe</dd>
-            <dt>Model</dt><dd>opus</dd>
+            <dt>Model</dt><dd>claude-opus-4-6</dd>
             <dt>Tools</dt><dd>+ edit</dd>
             <dt>Turns</dt><dd>50</dd>
           </dl>
@@ -175,7 +175,7 @@
           <p class="motto">“Will it stay working?”</p>
           <dl class="stats">
             <dt>Cmd</dt><dd class="cmd">/pippen</dd>
-            <dt>Model</dt><dd>opus</dd>
+            <dt>Model</dt><dd>claude-opus-4-6</dd>
             <dt>Tools</dt><dd>read-only</dd>
             <dt>Turns</dt><dd>50</dd>
           </dl>
@@ -190,7 +190,7 @@
           <p class="motto">“Summarize everything.”</p>
           <dl class="stats">
             <dt>Cmd</dt><dd class="cmd">/magic</dd>
-            <dt>Model</dt><dd>sonnet</dd>
+            <dt>Model</dt><dd>claude-sonnet-4-6</dd>
             <dt>Tools</dt><dd>+ write</dd>
             <dt>Turns</dt><dd>50</dd>
           </dl>

--- a/web/index.ts
+++ b/web/index.ts
@@ -32,6 +32,7 @@ import {
   draftDryRunHandler,
   draftPromoteHandler,
 } from "./src/routes/scenarios.ts";
+import { adminModelsHandler, adminModelsSaveHandler } from "./src/routes/admin.ts";
 import { serveStatic } from "./src/routes/static.ts";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
@@ -58,6 +59,10 @@ router.get("/evals/:runId/results", evalResultsFragment);
 router.get("/evals/:runId/trace/:resultId", traceHandler);
 router.post("/api/eval-runs", startEvalRunHandler);
 router.get("/api/eval-runs/live", evalRunsSSEHandler);
+
+// Admin — agent model/version editor
+router.get("/admin/models", adminModelsHandler);
+router.post("/admin/models", adminModelsSaveHandler);
 
 // Scenario browser and editor
 router.get("/scenarios", scenariosListHandler);

--- a/web/src/models-api.ts
+++ b/web/src/models-api.ts
@@ -1,0 +1,133 @@
+/**
+ * Anthropic models API helper.
+ *
+ * Fetches the current list of Claude models from
+ *   https://api.anthropic.com/v1/models
+ * The `id` field returned by the API is the canonical model identifier — the
+ * same string that is stored in agent frontmatter (`model:`), accepted by
+ * `claude --model`, and rendered in docs/site. No transformation is applied.
+ *
+ * On missing/invalid `ANTHROPIC_API_KEY` or any network error, falls back to
+ * a curated static list so the UI keeps working offline.
+ */
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Claude Code model aliases. These are NOT returned by the API — they're
+ * Claude Code pseudo-IDs that resolve to the current default Opus/Sonnet/etc.
+ * `opusplan` enables plan mode.
+ */
+export const CLAUDE_CODE_ALIASES = ["opus", "sonnet", "haiku", "opusplan"] as const;
+
+/**
+ * Static fallback list. Update when new models ship — the API is the source of
+ * truth at runtime, this is only the offline safety net.
+ */
+const FALLBACK_MODEL_IDS = [
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-opus-4-5",
+  "claude-sonnet-4-7",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
+];
+
+export type ModelRecord = {
+  /** Canonical model id. Store this in agent frontmatter / --model / docs. */
+  id: string;
+  /** Human-friendly label (falls back to id if the API didn't return one). */
+  displayName: string;
+  /** ISO timestamp from the API, used for sorting. May be empty for fallback. */
+  createdAt: string;
+};
+
+export type ModelsResult = {
+  fetchedAt: number;
+  source: "api" | "fallback";
+  models: ModelRecord[];
+  /** Populated when source === "fallback" to explain why. */
+  error?: string;
+};
+
+let cache: ModelsResult | null = null;
+
+/**
+ * Get the current list of Claude models, cached for 1h.
+ * Never throws — always returns a usable list (API result or fallback).
+ */
+export async function getAvailableModels(opts?: { forceRefresh?: boolean }): Promise<ModelsResult> {
+  const now = Date.now();
+  if (!opts?.forceRefresh && cache && now - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey || apiKey.trim().length === 0) {
+    cache = {
+      fetchedAt: now,
+      source: "fallback",
+      models: FALLBACK_MODEL_IDS.map((id) => ({ id, displayName: id, createdAt: "" })),
+      error: "ANTHROPIC_API_KEY is not set — using static fallback list",
+    };
+    return cache;
+  }
+
+  try {
+    const models = await fetchFromApi(apiKey.trim());
+    // Sort newest first so users pick the latest by default.
+    models.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""));
+    cache = { fetchedAt: now, source: "api", models };
+    return cache;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    cache = {
+      fetchedAt: now,
+      source: "fallback",
+      models: FALLBACK_MODEL_IDS.map((id) => ({ id, displayName: id, createdAt: "" })),
+      error: `API fetch failed (${message}) — using static fallback list`,
+    };
+    return cache;
+  }
+}
+
+async function fetchFromApi(apiKey: string): Promise<ModelRecord[]> {
+  const results: ModelRecord[] = [];
+  let url: string | null = "https://api.anthropic.com/v1/models?limit=100";
+
+  while (url) {
+    const resp = await fetch(url, {
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`HTTP ${resp.status}: ${body.slice(0, 200)}`);
+    }
+
+    const json = (await resp.json()) as {
+      data?: Array<{ id: string; display_name?: string; created_at?: string }>;
+      has_more?: boolean;
+      last_id?: string;
+    };
+
+    for (const m of json.data ?? []) {
+      results.push({
+        id: m.id,
+        displayName: m.display_name && m.display_name.length > 0 ? m.display_name : m.id,
+        createdAt: m.created_at ?? "",
+      });
+    }
+
+    url = json.has_more && json.last_id
+      ? `https://api.anthropic.com/v1/models?limit=100&after_id=${encodeURIComponent(json.last_id)}`
+      : null;
+  }
+
+  // Only Claude models — the account may technically expose other provider models.
+  return results.filter((m) => m.id.startsWith("claude-"));
+}

--- a/web/src/routes/admin.ts
+++ b/web/src/routes/admin.ts
@@ -1,0 +1,167 @@
+/**
+ * Admin routes — agent model/version editor
+ *
+ * GET  /admin/models  -> render form pre-filled with current `model:` frontmatter
+ * POST /admin/models  -> rewrite agents/<name>.md for each agent that changed.
+ *                        Does NOT run scripts/install.ts — the repo is the source of
+ *                        truth; syncing to ~/.claude/ is an explicit separate step
+ *                        (run `bun scripts/install.ts` in a terminal when ready).
+ */
+import path from "path";
+import fs from "fs";
+import { Layout, maybeLayout } from "../views/Layout.ts";
+import { AdminModelsPage, type AgentModelRow, type FlashMessage } from "../views/Admin.ts";
+import { getAvailableModels } from "../models-api.ts";
+
+function html(content: string, status = 200): Response {
+  return new Response(content, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+const REPO_ROOT = path.join(import.meta.dir, "../../../");
+const AGENTS_DIR = path.join(REPO_ROOT, "agents");
+
+/** List of canonical agents (directory scan). */
+function listAgentFiles(): string[] {
+  return fs
+    .readdirSync(AGENTS_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .sort();
+}
+
+/** Read the `model:` frontmatter value from an agent file, or "" if missing. */
+function readAgentModel(filePath: string): string {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^model:\s*(.+)$/m);
+  return match ? match[1].trim() : "";
+}
+
+function loadRows(): AgentModelRow[] {
+  return listAgentFiles().map((fname) => {
+    const agent = fname.replace(/\.md$/, "");
+    const model = readAgentModel(path.join(AGENTS_DIR, fname));
+    return { agent, currentModel: model };
+  });
+}
+
+/** GET /admin/models */
+export async function adminModelsHandler(req: Request, _params: Record<string, string>): Promise<Response> {
+  const [rows, modelsResult] = await Promise.all([
+    Promise.resolve(loadRows()),
+    getAvailableModels(),
+  ]);
+  const body = AdminModelsPage(rows, modelsResult);
+  return html(maybeLayout(req, "Agent Models", body, "/admin/models"));
+}
+
+/** Rewrite the `model:` line (or insert after `name:`) in an agent file. */
+function writeAgentModel(filePath: string, newModel: string): void {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const modelLineRe = /^model:\s*.+$/m;
+  let next: string;
+  if (modelLineRe.test(content)) {
+    next = content.replace(modelLineRe, `model: ${newModel}`);
+  } else {
+    // Insert a model line after the first `name:` line within the frontmatter.
+    next = content.replace(/^name:\s*.+$/m, (m) => `${m}\nmodel: ${newModel}`);
+  }
+  fs.writeFileSync(filePath, next, "utf-8");
+}
+
+/** Validate a model string — reject empty, multi-line, or obviously malformed input. */
+function validateModelValue(value: string): { ok: true } | { ok: false; reason: string } {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return { ok: false, reason: "model cannot be empty" };
+  if (/\s/.test(trimmed)) return { ok: false, reason: "model must not contain whitespace" };
+  if (trimmed.length > 100) return { ok: false, reason: "model value too long" };
+  // Allow identifiers like `claude-opus-4-7`, `opus`, `opusplan`, `claude-sonnet-4-5-20250929`
+  if (!/^[a-zA-Z0-9._:\-\[\]]+$/.test(trimmed)) {
+    return { ok: false, reason: "model contains invalid characters" };
+  }
+  return { ok: true };
+}
+
+async function renderFlash(req: Request, flash: FlashMessage): Promise<Response> {
+  const modelsResult = await getAvailableModels();
+  const body = AdminModelsPage(loadRows(), modelsResult, flash);
+  const status = flash.kind === "success" ? 200 : 400;
+  return new Response(
+    req.headers.get("HX-Request") ? body : Layout("Agent Models", body, "/admin/models"),
+    { status, headers: { "Content-Type": "text/html; charset=utf-8" } },
+  );
+}
+
+/** POST /admin/models */
+export async function adminModelsSaveHandler(req: Request, _params: Record<string, string>): Promise<Response> {
+  const contentType = req.headers.get("content-type") ?? "";
+  const incoming: Record<string, string> = {};
+
+  try {
+    if (contentType.includes("application/x-www-form-urlencoded")) {
+      const text = await req.text();
+      const params = new URLSearchParams(text);
+      for (const [k, v] of params.entries()) {
+        if (k.startsWith("model__")) incoming[k.slice("model__".length)] = v;
+      }
+    } else if (contentType.includes("application/json")) {
+      const body = (await req.json()) as Record<string, unknown>;
+      const models = body.models;
+      if (models && typeof models === "object" && !Array.isArray(models)) {
+        for (const [k, v] of Object.entries(models as Record<string, unknown>)) {
+          if (typeof v === "string") incoming[k] = v;
+        }
+      }
+    }
+  } catch (err) {
+    return renderFlash(req, {
+      kind: "error",
+      message: `Could not parse request body: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+
+  const agentFiles = new Map(listAgentFiles().map((f) => [f.replace(/\.md$/, ""), f] as const));
+  const changes: Array<{ agent: string; from: string; to: string }> = [];
+
+  for (const [agent, newModel] of Object.entries(incoming)) {
+    const fname = agentFiles.get(agent);
+    if (!fname) {
+      return renderFlash(req, { kind: "error", message: `Unknown agent: ${agent}` });
+    }
+    const validation = validateModelValue(newModel);
+    if (!validation.ok) {
+      return renderFlash(req, {
+        kind: "error",
+        message: `Invalid model for ${agent}: ${validation.reason}`,
+      });
+    }
+    const filePath = path.join(AGENTS_DIR, fname);
+    const current = readAgentModel(filePath);
+    const trimmed = newModel.trim();
+    if (current !== trimmed) {
+      changes.push({ agent, from: current, to: trimmed });
+    }
+  }
+
+  if (changes.length === 0) {
+    return renderFlash(req, {
+      kind: "success",
+      message: "No changes — all agents already match the submitted models.",
+    });
+  }
+
+  for (const { agent, to } of changes) {
+    writeAgentModel(path.join(AGENTS_DIR, agentFiles.get(agent)!), to);
+  }
+
+  const summary = changes
+    .map((c) => `${c.agent}: ${c.from || "(unset)"} → ${c.to}`)
+    .join(", ");
+
+  return renderFlash(req, {
+    kind: "success",
+    message: `Saved ${changes.length} agent spec(s) to agents/*.md: ${summary}. Next: run \`bun scripts/install.ts\` to sync into ~/.claude/, and \`bun scripts/build-site.ts\` to refresh site/index.html.`,
+  });
+}
+

--- a/web/src/routes/evals.ts
+++ b/web/src/routes/evals.ts
@@ -12,6 +12,7 @@ import { DashboardPage } from "../views/Dashboard.ts";
 import { EvalRunPage, ResultsTableFragment } from "../views/EvalRun.ts";
 import { TraceViewerPage } from "../views/TraceViewer.ts";
 import { NewEvalRunPage, type ScenarioGroup } from "../views/NewEvalRun.ts";
+import { getAvailableModels } from "../models-api.ts";
 import { EvalRunLivePage } from "../views/EvalRunLive.ts";
 import { startEvalRun, getActiveRun, createSSEResponse } from "../sse.ts";
 import path from "path";
@@ -145,11 +146,17 @@ function loadScenarioGroups(): ScenarioGroup[] {
 }
 
 /** GET /evals/new — New eval run config form */
-export function newEvalRunHandler(req: Request, _params: Record<string, string>): Response {
+export async function newEvalRunHandler(req: Request, _params: Record<string, string>): Promise<Response> {
   const activeRun = getActiveRun();
   const runInProgress = activeRun != null && !activeRun.done;
   const scenarioGroups = loadScenarioGroups();
-  const body = NewEvalRunPage(runInProgress, scenarioGroups, runInProgress ? activeRun!.runId : undefined);
+  const modelsResult = await getAvailableModels();
+  const body = NewEvalRunPage(
+    runInProgress,
+    scenarioGroups,
+    modelsResult,
+    runInProgress ? activeRun!.runId : undefined,
+  );
   return html(maybeLayout(req, "New Eval Run", body, "/evals/new"));
 }
 
@@ -159,6 +166,7 @@ export async function startEvalRunHandler(req: Request, _params: Record<string, 
   let scenarios: string[] = [];
   let trials = 3;
   let parallel = 5;
+  let model = "";
 
   try {
     const contentType = req.headers.get("content-type") ?? "";
@@ -169,6 +177,7 @@ export async function startEvalRunHandler(req: Request, _params: Record<string, 
       scenarios = params.getAll("scenarios");
       trials = parseInt(params.get("trials") ?? "3", 10) || 3;
       parallel = parseInt(params.get("parallel") ?? "5", 10) || 5;
+      model = (params.get("model") ?? "").trim();
     } else if (contentType.includes("application/json")) {
       const body = await req.json() as Record<string, unknown>;
       agents = Array.isArray(body.agents) ? body.agents as string[] : [];
@@ -180,6 +189,7 @@ export async function startEvalRunHandler(req: Request, _params: Record<string, 
       }
       trials = typeof body.trials === "number" ? body.trials : 3;
       parallel = typeof body.parallel === "number" ? body.parallel : 5;
+      model = typeof body.model === "string" ? body.model.trim() : "";
     }
   } catch (err) {
     console.error("Error parsing request body:", err);
@@ -190,7 +200,7 @@ export async function startEvalRunHandler(req: Request, _params: Record<string, 
   }
 
   try {
-    const runId = await startEvalRun({ agents, scenarios, trials, parallel });
+    const runId = await startEvalRun({ agents, scenarios, trials, parallel, model });
     // Redirect to live progress page (works for both form submit and JSON)
     const accept = req.headers.get("accept") ?? "";
     if (accept.includes("application/json")) {

--- a/web/src/sse.ts
+++ b/web/src/sse.ts
@@ -33,6 +33,7 @@ function buildArgs(opts: {
   trials: number;
   parallel: number;
   timeoutPerPhase?: number;
+  model?: string;
 }): string[] {
   const args: string[] = [];
 
@@ -51,6 +52,10 @@ function buildArgs(opts: {
 
   if (opts.timeoutPerPhase && opts.timeoutPerPhase > 0) {
     args.push("--timeout-per-phase", String(opts.timeoutPerPhase));
+  }
+
+  if (opts.model && opts.model.trim().length > 0) {
+    args.push("--model", opts.model.trim());
   }
 
   return args;
@@ -85,6 +90,7 @@ export async function startEvalRun(opts: {
   trials: number;
   parallel: number;
   timeoutPerPhase?: number;
+  model?: string;
 }): Promise<string> {
   if (activeRun && !activeRun.done) {
     throw new Error("A run is already in progress");

--- a/web/src/views/Admin.ts
+++ b/web/src/views/Admin.ts
@@ -1,0 +1,145 @@
+/**
+ * Admin — model/version editor for agent frontmatter (/admin/models)
+ *
+ * Writes changes to agents/<name>.md in the repo (source of truth). Syncing to
+ * ~/.claude/ is a separate manual step (`bun scripts/install.ts`).
+ */
+import { esc } from "./html.ts";
+import type { ModelsResult } from "../models-api.ts";
+import { CLAUDE_CODE_ALIASES } from "../models-api.ts";
+
+export type AgentModelRow = {
+  agent: string;
+  currentModel: string;
+};
+
+export type FlashMessage = {
+  kind: "success" | "error";
+  message: string;
+};
+
+/** Render the <select> for one agent row. Groups: aliases, API ids, current-unknown. */
+function renderSelect(agent: string, currentModel: string, modelsResult: ModelsResult): string {
+  const apiIds = modelsResult.models.map((m) => m.id);
+  const aliasList: readonly string[] = CLAUDE_CODE_ALIASES;
+
+  const inAliases = aliasList.includes(currentModel);
+  const inApi = apiIds.includes(currentModel);
+  const unknown = currentModel.length > 0 && !inAliases && !inApi;
+
+  const aliasOptions = aliasList
+    .map((alias) => {
+      const selected = currentModel === alias ? " selected" : "";
+      return `<option value="${esc(alias)}"${selected}>${esc(alias)}</option>`;
+    })
+    .join("");
+
+  const apiOptions = modelsResult.models
+    .map((m) => {
+      const selected = currentModel === m.id ? " selected" : "";
+      const label = m.displayName && m.displayName !== m.id ? `${m.id} — ${m.displayName}` : m.id;
+      return `<option value="${esc(m.id)}"${selected}>${esc(label)}</option>`;
+    })
+    .join("");
+
+  const unknownOption = unknown
+    ? `<optgroup label="Current value (not in list)"><option value="${esc(currentModel)}" selected>${esc(currentModel)}</option></optgroup>`
+    : "";
+
+  const sourceLabel = modelsResult.source === "api" ? "Pinned model IDs (Anthropic API)" : "Pinned model IDs (fallback list)";
+
+  return `
+    <select id="model-${esc(agent)}" name="model__${esc(agent)}" class="form-input">
+      ${unknownOption}
+      <optgroup label="Claude Code aliases">${aliasOptions}</optgroup>
+      <optgroup label="${esc(sourceLabel)}">${apiOptions}</optgroup>
+    </select>
+  `;
+}
+
+/** Render a small banner describing where the model list came from. */
+function renderModelsSource(modelsResult: ModelsResult): string {
+  const ageMins = Math.floor((Date.now() - modelsResult.fetchedAt) / 60_000);
+  const ageLabel = ageMins <= 0 ? "just now" : `${ageMins}m ago`;
+  if (modelsResult.source === "api") {
+    return `
+      <div class="source-banner source-ok">
+        <strong>Live:</strong> ${modelsResult.models.length} model IDs from Anthropic API (fetched ${ageLabel}).
+      </div>
+    `;
+  }
+  return `
+    <div class="source-banner source-warn">
+      <strong>Static list:</strong> ${esc(modelsResult.error ?? "using fallback")}. Set <code>ANTHROPIC_API_KEY</code> in <code>.env</code> at repo root for live IDs from the API.
+    </div>
+  `;
+}
+
+export function AdminModelsPage(
+  rows: AgentModelRow[],
+  modelsResult: ModelsResult,
+  flash?: FlashMessage,
+): string {
+  const rowsHtml = rows
+    .map(
+      (r) => `
+      <div class="admin-row">
+        <label class="admin-label" for="model-${esc(r.agent)}">
+          <span class="agent-badge ${esc(r.agent)}">${esc(r.agent)}</span>
+        </label>
+        ${renderSelect(r.agent, r.currentModel, modelsResult)}
+      </div>
+    `,
+    )
+    .join("");
+
+  const flashHtml = flash
+    ? `
+      <div class="flash flash-${flash.kind}">
+        <strong>${flash.kind === "success" ? "Saved." : "Error."}</strong>
+        ${esc(flash.message)}
+      </div>
+    `
+    : "";
+
+  return `
+    <div class="page-title">
+      <h1>Agent Models</h1>
+      <p>Set the <code>model:</code> frontmatter value for each agent. Saving writes to <code>agents/&lt;name&gt;.md</code> in the repo only — run <code>bun scripts/install.ts</code> separately to sync into <code>~/.claude/</code>.</p>
+    </div>
+
+    ${renderModelsSource(modelsResult)}
+    ${flashHtml}
+
+    <form method="POST" action="/admin/models" class="card" style="max-width:720px;padding:24px">
+      <div class="admin-grid">
+        ${rowsHtml}
+      </div>
+
+      <div style="display:flex;gap:12px;margin-top:20px;align-items:center">
+        <button type="submit" class="btn-primary">Save</button>
+        <span class="form-hint" style="color:var(--text-muted);font-size:12px">
+          Selected value is written verbatim to <code>agents/&lt;agent&gt;.md</code>'s <code>model:</code> field and used directly by <code>claude --model</code>, eval runs, and docs.
+        </span>
+      </div>
+    </form>
+
+    <style>
+      .admin-grid { display: flex; flex-direction: column; gap: 12px; }
+      .admin-row { display: grid; grid-template-columns: 120px 1fr; align-items: center; gap: 12px; }
+      .admin-label { display: flex; align-items: center; }
+      .form-input { width: 100%; background: var(--surface-3); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 13px; font-family: var(--mono, monospace); padding: 8px 12px; outline: none; transition: border-color 0.15s; box-sizing: border-box; }
+      .form-input:focus { border-color: var(--accent); }
+      select.form-input { appearance: auto; cursor: pointer; }
+      .btn-primary { display: inline-block; background: var(--accent); color: #fff; border: none; border-radius: 6px; padding: 10px 20px; font-size: 14px; font-weight: 600; cursor: pointer; text-decoration: none; transition: opacity 0.15s; }
+      .btn-primary:hover { opacity: 0.85; }
+      .flash { padding: 12px 16px; border-radius: 6px; margin-bottom: 16px; font-size: 13px; }
+      .flash-success { background: rgba(34, 197, 94, 0.12); border: 1px solid rgba(34, 197, 94, 0.4); color: #86efac; }
+      .flash-error { background: rgba(239, 68, 68, 0.12); border: 1px solid rgba(239, 68, 68, 0.4); color: #fca5a5; }
+      .source-banner { padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; font-size: 12px; color: var(--text-dim); }
+      .source-ok { background: rgba(59, 130, 246, 0.08); border: 1px solid rgba(59, 130, 246, 0.3); }
+      .source-warn { background: rgba(234, 179, 8, 0.08); border: 1px solid rgba(234, 179, 8, 0.3); color: #fcd34d; }
+      .source-banner code { background: var(--surface-3); padding: 1px 4px; border-radius: 3px; }
+    </style>
+  `;
+}

--- a/web/src/views/Layout.ts
+++ b/web/src/views/Layout.ts
@@ -5,6 +5,7 @@ export function Layout(title: string, body: string, activeNav = ""): string {
   const navItems = [
     { href: "/", label: "Dashboard" },
     { href: "/scenarios", label: "Scenarios" },
+    { href: "/admin/models", label: "Admin" },
   ];
   const navLinks = navItems.map(item => {
     const active = activeNav === item.href ? ' style="color:var(--text)"' : "";

--- a/web/src/views/NewEvalRun.ts
+++ b/web/src/views/NewEvalRun.ts
@@ -1,15 +1,45 @@
 /**
  * New Eval Run form page — /evals/new
  */
+import { CLAUDE_CODE_ALIASES, type ModelsResult } from "../models-api.ts";
 
 export type ScenarioGroup = {
   agent: string;
   scenarios: string[]; // bare scenario IDs e.g. "scenario-01-foo"
 };
 
+function renderModelSelect(modelsResult: ModelsResult): string {
+  const aliasList: readonly string[] = CLAUDE_CODE_ALIASES;
+  const aliasOptions = aliasList
+    .map((alias) => `<option value="${alias}">${alias}</option>`)
+    .join("");
+  const apiOptions = modelsResult.models
+    .map((m) => {
+      const label = m.displayName && m.displayName !== m.id ? `${m.id} — ${m.displayName}` : m.id;
+      return `<option value="${m.id}">${label}</option>`;
+    })
+    .join("");
+  const sourceLabel = modelsResult.source === "api"
+    ? "Pinned model IDs (Anthropic API)"
+    : "Pinned model IDs (fallback list)";
+  const sourceNote = modelsResult.source === "api"
+    ? ""
+    : `<span style="display:block;color:var(--text-muted);font-size:11px;margin-top:4px">List source: static fallback (ANTHROPIC_API_KEY not set or API unreachable).</span>`;
+
+  return `
+    <select id="model" name="model" class="form-input">
+      <option value="" selected>(use each agent's frontmatter)</option>
+      <optgroup label="Claude Code aliases">${aliasOptions}</optgroup>
+      <optgroup label="${sourceLabel}">${apiOptions}</optgroup>
+    </select>
+    ${sourceNote}
+  `;
+}
+
 export function NewEvalRunPage(
   runInProgress: boolean,
   scenarioGroups: ScenarioGroup[],
+  modelsResult: ModelsResult,
   activeRunId?: string
 ): string {
   if (runInProgress) {
@@ -122,6 +152,14 @@ export function NewEvalRunPage(
             max="20"
           >
         </div>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="model">
+          Model override
+          <span class="form-hint">(optional — leave on default to use each agent's frontmatter; overrides phase-1 only, judge stays on default)</span>
+        </label>
+        ${renderModelSelect(modelsResult)}
       </div>
 
       <button type="submit" class="btn-primary" style="width:100%;margin-top:8px">


### PR DESCRIPTION
## Summary

Pin all 7 agents to specific 4.6 builds so we can run a baseline and compare cleanly against 4.7. Adds web UI + CLI controls to manage model selection, plus automatic site sync so marketing docs stay accurate.

## What changed

- **Agents pinned**: 6 on `claude-opus-4-6`, magic on `claude-sonnet-4-6`. Shaq's `opusplan` alias dropped (plan mode sacrificed for a comparable baseline). All docs (README, team.md, site/index.html) updated.
- **Eval CLI** (`evals/src/cli.ts`): new `--model <id>` flag applies only to phase-1 agent runs; the Coach K scoring judge stays on the default so 4.6 vs 4.7 runs share a constant baseline. Model is recorded in result `meta.model`.
- **Web admin** (`/admin/models`): edit each agent's `model:` frontmatter via a `<select>` populated live from `GET /v1/models` (Anthropic API, 1h cache, falls back to a static list when `ANTHROPIC_API_KEY` is unset). Writes `agents/*.md` only — install sync is a separate step the user controls. Admin link added to nav.
- **New Eval Run form** (`/evals/new`): `--model` override field uses the same select. Blank = use each agent's frontmatter.
- **Site parity**: `scripts/build-site.ts` mirrors `agents/*.md` model values into `site/index.html` (6 agent cards). Wired into the GH Pages deploy workflow before commit-SHA injection; `--check` mode for drift detection. Deploy now also triggers on `agents/**` changes.
- **README** updated with the end-to-end model-sweep workflow: admin → install → build-site → eval.

## Test plan

- [ ] `bun test evals/src/__tests__/ web/src/__tests__/` — all 160 existing tests pass
- [ ] `bun evals/src/cli.ts --help` — shows new `--model` flag
- [ ] `bun evals/src/cli.ts --dry-run --model claude-opus-4-7` — logs `Model: claude-opus-4-7 [judge unchanged]`
- [ ] `bun scripts/build-site.ts --check` — exits 0 when agent specs and site are in sync
- [ ] `bun web/index.ts` then visit `/admin/models` — 7 agents shown with current models preselected, live banner shows API source when `ANTHROPIC_API_KEY` is set
- [ ] Save a model change via web admin → confirm `agents/<name>.md` is rewritten and `~/.claude/` is NOT touched
- [ ] Visit `/evals/new` — `--model` override renders as select, default option is "(use each agent's frontmatter)"
- [ ] Confirm GH Pages deploy still succeeds with the new `setup-bun` + `build-site.ts` steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)