### PR TITLE
fix(ci): install deps in test workflow + repair stale scorer test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Run eval tests
         run: bun test evals/src/__tests__/
 

--- a/evals/src/__tests__/scorer-trials.test.ts
+++ b/evals/src/__tests__/scorer-trials.test.ts
@@ -11,6 +11,9 @@
 
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import fs from "fs";
+
+// Avoid real retry-backoff sleeps in unit tests (scorer reads this at call time).
+process.env.EVAL_SCORING_BACKOFF_MS = "0";
 import os from "os";
 import path from "path";
 import type { ClaudeAdapter, GraderResult, RawOutput } from "../types.ts";
@@ -159,12 +162,12 @@ describe("scoreSingleTrial", () => {
     expect(result!.grader_results).toEqual(graderResults);
   });
 
-  test("score forced to 'fail' when LLM returns unparseable output (after retry)", async () => {
+  test("score forced to 'error' when LLM returns unparseable output (after retries exhausted)", async () => {
     const rawPath = path.join(tmpDir, "shaq-scenario-01.json");
     fs.writeFileSync(rawPath, JSON.stringify(makeRawOutput()));
 
-    // Both attempts return unparseable output
-    const adapter = new MockAdapter(["not json at all", "still not json"]);
+    // Every attempt returns unparseable output
+    const adapter = new MockAdapter(["not json at all", "still not json", "nope"]);
 
     const result = await scoreSingleTrial(
       "shaq",
@@ -180,9 +183,11 @@ describe("scoreSingleTrial", () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.score).toBe("fail");
+    // A judge that never produces parseable output is a judge failure ('error'),
+    // not a model failure ('fail') — see scoreSingleTrial.
+    expect(result!.score).toBe("error");
     expect(result!.confidence_stated).toBe(0);
-    expect(adapter.calls).toHaveLength(2); // one retry was made
+    expect(adapter.calls).toHaveLength(3); // all retries exhausted
   });
 
   test("retry succeeds: first LLM call returns garbage, second returns valid JSON", async () => {

--- a/evals/src/scorer.ts
+++ b/evals/src/scorer.ts
@@ -142,7 +142,9 @@ async function invokeScoringClaude(
     // rate/usage throttling on the judge call; a short, growing pause lets them clear.
     if (attempt < MAX_ATTEMPTS - 1) {
       console.log(`  RETRY scoring parse for ${label} (attempt ${attempt + 2}/${MAX_ATTEMPTS})`);
-      await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+      // Backoff base is overridable (set to 0 in unit tests to avoid real sleeps).
+      const backoffBaseMs = Number(process.env.EVAL_SCORING_BACKOFF_MS ?? 2000);
+      await new Promise((r) => setTimeout(r, backoffBaseMs * (attempt + 1)));
     }
   }
 

--- a/web/src/__tests__/sessions-source.test.ts
+++ b/web/src/__tests__/sessions-source.test.ts
@@ -1,5 +1,50 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeAll, afterAll } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+// projectsDir() reads CLAUDE_PROJECTS_DIR at call time, so a static import is
+// fine — the env var only needs to be set before the test bodies run.
 import { listProjects, listSessions, loadSession } from "../sessions-source.ts";
+
+// Point sessions-source at a hermetic fixture instead of the real
+// ~/.claude/projects (which doesn't exist in CI and varies per machine).
+let tmpRoot: string;
+
+function writeSession(projectDir: string, id: string, records: unknown[]) {
+  const dir = path.join(tmpRoot, projectDir);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.jsonl`), records.map(r => JSON.stringify(r)).join("\n"));
+}
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sessions-src-"));
+  process.env.CLAUDE_PROJECTS_DIR = tmpRoot;
+
+  // Project A — two human sessions (newest has the later end timestamp).
+  writeSession("-tmp-projA", "sess-old", [
+    { type: "user", timestamp: "2026-01-01T00:00:00Z", gitBranch: "main", message: { role: "user", content: "please add a function" } },
+    { type: "assistant", timestamp: "2026-01-01T00:01:00Z", message: { role: "assistant", model: "claude-opus-4-8", usage: { input_tokens: 10, output_tokens: 5 }, content: [{ type: "tool_use", name: "Edit", id: "t1", input: { file_path: "/tmp/x.ts", old_string: "a", new_string: "a\nb\nc" } }] } },
+  ]);
+  writeSession("-tmp-projA", "sess-new", [
+    { type: "user", timestamp: "2026-02-01T00:00:00Z", gitBranch: "main", message: { role: "user", content: "another human prompt" } },
+    { type: "assistant", timestamp: "2026-02-01T00:02:00Z", message: { role: "assistant", model: "claude-opus-4-8", usage: { input_tokens: 3, output_tokens: 2 }, content: [{ type: "text", text: "done" }] } },
+  ]);
+  // A headless session (no human-typed prompt) — excluded from listSessions by default.
+  writeSession("-tmp-projA", "sess-headless", [
+    { type: "user", timestamp: "2026-01-03T00:00:00Z", isSidechain: true, message: { role: "user", content: "sidechain only" } },
+    { type: "assistant", timestamp: "2026-01-03T00:00:30Z", message: { role: "assistant", model: "<synthetic>", content: [{ type: "text", text: "auto" }] } },
+  ]);
+
+  // Excluded project — must never appear in listProjects/listSessions.
+  writeSession("-Users-lb-Github-Bondarewicz-dreamteam-evals", "sess-eval", [
+    { type: "user", timestamp: "2026-03-01T00:00:00Z", message: { role: "user", content: "eval run" } },
+  ]);
+});
+
+afterAll(() => {
+  delete process.env.CLAUDE_PROJECTS_DIR;
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
 
 test("listProjects excludes dreamteam-evals and returns counts", () => {
   const projects = listProjects();
@@ -11,10 +56,13 @@ test("listProjects excludes dreamteam-evals and returns counts", () => {
 test("listSessions returns newest-first summaries with sane fields", () => {
   const sessions = listSessions({ limit: 50 });
   expect(sessions.length).toBeGreaterThan(0);
+  // headless excluded by default → only the two human sessions of projA
+  expect(sessions.length).toBe(2);
   // newest-first
   for (let i = 1; i < sessions.length; i++) {
     expect(new Date(sessions[i - 1].end).getTime()).toBeGreaterThanOrEqual(new Date(sessions[i].end).getTime());
   }
+  expect(sessions[0].id).toBe("sess-new");
   for (const s of sessions) {
     expect(s.id).toBeTruthy();
     expect(s.durationMs).toBeGreaterThanOrEqual(0);
@@ -25,11 +73,13 @@ test("listSessions returns newest-first summaries with sane fields", () => {
 });
 
 test("loadSession returns full records + per-file changes", () => {
-  const first = listSessions({ limit: 1 })[0];
-  const detail = loadSession(first.project, first.id);
+  const detail = loadSession("-tmp-projA", "sess-old");
   expect(detail).not.toBeNull();
-  expect(detail!.records_raw.length).toBe(first.records);
+  expect(detail!.records_raw.length).toBe(detail!.records);
   expect(detail!.filesChanged).toBe(detail!.files.length);
   const sumAdded = detail!.files.reduce((a, f) => a + f.added, 0);
   expect(sumAdded).toBe(detail!.linesAdded);
+  // Edit added "a\nb\nc" (3 lines), removed "a" (1 line).
+  expect(detail!.linesAdded).toBe(3);
+  expect(detail!.linesRemoved).toBe(1);
 });

--- a/web/src/sessions-source.ts
+++ b/web/src/sessions-source.ts
@@ -11,7 +11,11 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
-const PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
+// Resolved at call time so tests (and alternate hosts) can point at a fixture
+// directory via CLAUDE_PROJECTS_DIR instead of the real ~/.claude/projects.
+function projectsDir(): string {
+  return process.env.CLAUDE_PROJECTS_DIR || path.join(os.homedir(), ".claude", "projects");
+}
 
 /** Projects excluded from indexing entirely (automated eval-runner noise). */
 const EXCLUDED_PROJECTS = new Set(["-Users-lb-Github-Bondarewicz-dreamteam-evals"]);
@@ -227,11 +231,12 @@ function summarize(project: string, file: string): SessionSummary | null {
 
 // ── public API ────────────────────────────────────────────────
 export function listProjects(): Array<{ dir: string; label: string; sessions: number }> {
-  if (!fs.existsSync(PROJECTS_DIR)) return [];
+  const root = projectsDir();
+  if (!fs.existsSync(root)) return [];
   const out: Array<{ dir: string; label: string; sessions: number }> = [];
-  for (const dir of fs.readdirSync(PROJECTS_DIR)) {
+  for (const dir of fs.readdirSync(root)) {
     if (EXCLUDED_PROJECTS.has(dir)) continue;
-    const full = path.join(PROJECTS_DIR, dir);
+    const full = path.join(root, dir);
     let n = 0;
     try {
       if (!fs.statSync(full).isDirectory()) continue;
@@ -246,11 +251,12 @@ export type ListOpts = { project?: string; includeHeadless?: boolean; limit?: nu
 
 /** List session summaries (newest first). Excludes excluded projects + headless by default. */
 export function listSessions(opts: ListOpts = {}): SessionSummary[] {
+  const root = projectsDir();
   const projects = opts.project ? [opts.project] : listProjects().map(p => p.dir);
   const summaries: SessionSummary[] = [];
   for (const dir of projects) {
     if (EXCLUDED_PROJECTS.has(dir)) continue;
-    const full = path.join(PROJECTS_DIR, dir);
+    const full = path.join(root, dir);
     let files: string[] = [];
     try { files = fs.readdirSync(full).filter(f => f.endsWith(".jsonl")); } catch { continue; }
     for (const f of files) {
@@ -265,7 +271,7 @@ export function listSessions(opts: ListOpts = {}): SessionSummary[] {
 }
 
 export function loadSession(project: string, id: string): SessionDetail | null {
-  const file = path.join(PROJECTS_DIR, project, `${id}.jsonl`);
+  const file = path.join(projectsDir(), project, `${id}.jsonl`);
   const summary = summarize(project, file);
   if (!summary) return null;
   const records = readJsonl(file);


### PR DESCRIPTION
## Why CI was red on `main`

Two independent failures in the **Tests** workflow ([run #27538383448](https://github.com/bondarewicz/dreamteam/actions/runs/27538383448/job/81393529428)):

### 1. Dependencies never installed
`test.yml` ran `bun test …` directly without `bun install`. Tests importing `zod` (via `schemas/agent-schemas.ts`) failed with `Cannot find package 'zod'` → 5 errors.

**Fix:** add a `bun install --frozen-lockfile` step (`bun.lock` is committed and in sync).

### 2. Stale scorer unit test
Commit `89f4e4a` changed the scorer so unparseable judge output maps to `score: "error"` (not `"fail"`) and retries 3× with a 2s+4s backoff. `scorer-trials.test.ts` still asserted `"fail"` / 2 calls **and** ran the real 6s backoff, blowing the 5000ms test timeout.

**Fix:**
- Update assertions to the intended `"error"` / 3-attempt behavior (the code was correct; the test was stale).
- Make the retry backoff base overridable via `EVAL_SCORING_BACKOFF_MS`, set to `0` in tests so unit tests don't sleep (eval suite: ~120ms vs 7s).

## Verification
Faithful CI repro on a fresh clone + frozen install — all three steps green:
- eval tests: 227 pass / 0 fail
- web tests: 28 pass / 0 fail
- site sync check: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)